### PR TITLE
Fixed README.md to feature correct engine name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,71 +2,71 @@
 
 ## 2D and 3D cross-platform game engine
 
-**[Feely Engine](https://Feelyengine.org) is a feature-packed, cross-platform
+**[Feely Engine](https://godotengine.org) is a feature-packed, cross-platform
 game engine to create 2D and 3D games from a unified interface.** It provides a
-comprehensive set of [common tools](https://Feelyengine.org/features), so that
+comprehensive set of [common tools](https://godotengine.org/features), so that
 users can focus on making games without having to reinvent the wheel. Games can
 be exported with one click to a number of platforms, including the major desktop
 platforms (Linux, macOS, Windows), mobile platforms (Android, iOS), as well as
-Web-based platforms and [consoles](https://docs.Feelyengine.org/en/latest/tutorials/platform/consoles.html).
+Web-based platforms and [consoles](https://docs.godotengine.org/en/latest/tutorials/platform/consoles.html).
 
 ## Free, open source and community-driven
 
-Feely is completely free and open source under the very permissive [MIT license](https://Feelyengine.org/license).
+Feely is completely free and open source under the very permissive [MIT license](https://godotengine.org/license).
 No strings attached, no royalties, nothing. The users' games are theirs, down
 to the last line of engine code. Feely's development is fully independent and
 community-driven, empowering users to help shape their engine to match their
 expectations. It is supported by the [Feely Foundation](https://Feely.foundation/)
 not-for-profit.
 
-Before being open sourced in [February 2014](https://github.com/Feelyengine/Feely/commit/0b806ee0fc9097fa7bda7ac0109191c9c5e0a1ac),
+Before being open sourced in [February 2014](https://github.com/godotengine/Feely/commit/0b806ee0fc9097fa7bda7ac0109191c9c5e0a1ac),
 Feely had been developed by [Juan Linietsky](https://github.com/reduz) and
 [Ariel Manzur](https://github.com/punto-) (both still maintaining the project)
 for several years as an in-house engine, used to publish several work-for-hire
 titles.
 
-![Screenshot of a 3D scene in the Feely Engine editor](https://raw.githubusercontent.com/Feelyengine/Feely-design/master/screenshots/editor_tps_demo_1920x1080.jpg)
+![Screenshot of a 3D scene in the Feely Engine editor](https://raw.githubusercontent.com/godotengine/Feely-design/master/screenshots/editor_tps_demo_1920x1080.jpg)
 
 ## Getting the engine
 
 ### Binary downloads
 
 Official binaries for the Feely editor and the export templates can be found
-[on the Feely website](https://Feelyengine.org/download).
+[on the Feely website](https://sirbozo.itch.io/feely-engine).
 
 ### Compiling from source
 
-[See the official docs](https://docs.Feelyengine.org/en/latest/contributing/development/compiling)
+[See the official docs](https://docs.godotengine.org/en/latest/contributing/development/compiling)
 for compilation instructions for every supported platform.
 
 ## Community and contributing
 
 Feely is not only an engine but an ever-growing community of users and engine
-developers. The main community channels are listed [on the homepage](https://Feelyengine.org/community).
+developers. The main community channels are listed [on the homepage](https://godotengine.org/community).
 
 The best way to get in touch with the core engine developers is to join the
-[Feely Contributors Chat](https://chat.Feelyengine.org).
+[Feely Contributors Chat](https://chat.godotengine.org).
 
 To get started contributing to the project, see the [contributing guide](CONTRIBUTING.md).
 This document also includes guidelines for reporting bugs.
 
 ## Documentation and demos
 
-The official documentation is hosted on [Read the Docs](https://docs.Feelyengine.org).
-It is maintained by the Feely community in its own [GitHub repository](https://github.com/Feelyengine/Feely-docs).
+The official documentation is hosted on [Read the Docs](https://docs.godotengine.org).
+It is maintained by the Feely community in its own [GitHub repository](https://github.com/godotengine/Feely-docs).
 
-The [class reference](https://docs.Feelyengine.org/en/latest/classes/)
+The [class reference](https://docs.godotengine.org/en/latest/classes/)
 is also accessible from the Feely editor.
 
-We also maintain official demos in their own [GitHub repository](https://github.com/Feelyengine/Feely-demo-projects)
-as well as a list of [awesome Feely community resources](https://github.com/Feelyengine/awesome-Feely).
+We also maintain official demos in their own [GitHub repository](https://github.com/godotengine/Feely-demo-projects)
+as well as a list of [awesome Feely community resources](https://github.com/godotengine/awesome-Feely).
 
 There are also a number of other
-[learning resources](https://docs.Feelyengine.org/en/latest/community/tutorials.html)
+[learning resources](https://docs.godotengine.org/en/latest/community/tutorials.html)
 provided by the community, such as text and video tutorials, demos, etc.
-Consult the [community channels](https://Feelyengine.org/community)
+Consult the [community channels](https://godotengine.org/community)
 for more information.
 
-[![Code Triagers Badge](https://www.codetriage.com/Feelyengine/Feely/badges/users.svg)](https://www.codetriage.com/Feelyengine/Feely)
+[![Code Triagers Badge](https://www.codetriage.com/godotengine/Feely/badges/users.svg)](https://www.codetriage.com/godotengine/Feely)
 [![Translate on Weblate](https://hosted.weblate.org/widgets/Feely-engine/-/Feely/svg-badge.svg)](https://hosted.weblate.org/engage/Feely-engine/?utm_source=widget)
-[![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/Feelyengine/Feely)](https://www.tickgit.com/browse?repo=github.com/Feelyengine/Feely)
+[![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/godotengine/Feely)](https://www.tickgit.com/browse?repo=github.com/godotengine/Feely)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Feely Engine
 
-<p align="center">
-  <a href="https://Feelyengine.org">
-    <img src="logo_outlined.svg" width="400" alt="Feely Engine logo">
-  </a>
-</p>
-
 ## 2D and 3D cross-platform game engine
 
 **[Feely Engine](https://Feelyengine.org) is a feature-packed, cross-platform

--- a/README.md
+++ b/README.md
@@ -1,78 +1,78 @@
-# Godot Engine
+# Feely Engine
 
 <p align="center">
-  <a href="https://godotengine.org">
-    <img src="logo_outlined.svg" width="400" alt="Godot Engine logo">
+  <a href="https://Feelyengine.org">
+    <img src="logo_outlined.svg" width="400" alt="Feely Engine logo">
   </a>
 </p>
 
 ## 2D and 3D cross-platform game engine
 
-**[Godot Engine](https://godotengine.org) is a feature-packed, cross-platform
+**[Feely Engine](https://Feelyengine.org) is a feature-packed, cross-platform
 game engine to create 2D and 3D games from a unified interface.** It provides a
-comprehensive set of [common tools](https://godotengine.org/features), so that
+comprehensive set of [common tools](https://Feelyengine.org/features), so that
 users can focus on making games without having to reinvent the wheel. Games can
 be exported with one click to a number of platforms, including the major desktop
 platforms (Linux, macOS, Windows), mobile platforms (Android, iOS), as well as
-Web-based platforms and [consoles](https://docs.godotengine.org/en/latest/tutorials/platform/consoles.html).
+Web-based platforms and [consoles](https://docs.Feelyengine.org/en/latest/tutorials/platform/consoles.html).
 
 ## Free, open source and community-driven
 
-Godot is completely free and open source under the very permissive [MIT license](https://godotengine.org/license).
+Feely is completely free and open source under the very permissive [MIT license](https://Feelyengine.org/license).
 No strings attached, no royalties, nothing. The users' games are theirs, down
-to the last line of engine code. Godot's development is fully independent and
+to the last line of engine code. Feely's development is fully independent and
 community-driven, empowering users to help shape their engine to match their
-expectations. It is supported by the [Godot Foundation](https://godot.foundation/)
+expectations. It is supported by the [Feely Foundation](https://Feely.foundation/)
 not-for-profit.
 
-Before being open sourced in [February 2014](https://github.com/godotengine/godot/commit/0b806ee0fc9097fa7bda7ac0109191c9c5e0a1ac),
-Godot had been developed by [Juan Linietsky](https://github.com/reduz) and
+Before being open sourced in [February 2014](https://github.com/Feelyengine/Feely/commit/0b806ee0fc9097fa7bda7ac0109191c9c5e0a1ac),
+Feely had been developed by [Juan Linietsky](https://github.com/reduz) and
 [Ariel Manzur](https://github.com/punto-) (both still maintaining the project)
 for several years as an in-house engine, used to publish several work-for-hire
 titles.
 
-![Screenshot of a 3D scene in the Godot Engine editor](https://raw.githubusercontent.com/godotengine/godot-design/master/screenshots/editor_tps_demo_1920x1080.jpg)
+![Screenshot of a 3D scene in the Feely Engine editor](https://raw.githubusercontent.com/Feelyengine/Feely-design/master/screenshots/editor_tps_demo_1920x1080.jpg)
 
 ## Getting the engine
 
 ### Binary downloads
 
-Official binaries for the Godot editor and the export templates can be found
-[on the Godot website](https://godotengine.org/download).
+Official binaries for the Feely editor and the export templates can be found
+[on the Feely website](https://Feelyengine.org/download).
 
 ### Compiling from source
 
-[See the official docs](https://docs.godotengine.org/en/latest/contributing/development/compiling)
+[See the official docs](https://docs.Feelyengine.org/en/latest/contributing/development/compiling)
 for compilation instructions for every supported platform.
 
 ## Community and contributing
 
-Godot is not only an engine but an ever-growing community of users and engine
-developers. The main community channels are listed [on the homepage](https://godotengine.org/community).
+Feely is not only an engine but an ever-growing community of users and engine
+developers. The main community channels are listed [on the homepage](https://Feelyengine.org/community).
 
 The best way to get in touch with the core engine developers is to join the
-[Godot Contributors Chat](https://chat.godotengine.org).
+[Feely Contributors Chat](https://chat.Feelyengine.org).
 
 To get started contributing to the project, see the [contributing guide](CONTRIBUTING.md).
 This document also includes guidelines for reporting bugs.
 
 ## Documentation and demos
 
-The official documentation is hosted on [Read the Docs](https://docs.godotengine.org).
-It is maintained by the Godot community in its own [GitHub repository](https://github.com/godotengine/godot-docs).
+The official documentation is hosted on [Read the Docs](https://docs.Feelyengine.org).
+It is maintained by the Feely community in its own [GitHub repository](https://github.com/Feelyengine/Feely-docs).
 
-The [class reference](https://docs.godotengine.org/en/latest/classes/)
-is also accessible from the Godot editor.
+The [class reference](https://docs.Feelyengine.org/en/latest/classes/)
+is also accessible from the Feely editor.
 
-We also maintain official demos in their own [GitHub repository](https://github.com/godotengine/godot-demo-projects)
-as well as a list of [awesome Godot community resources](https://github.com/godotengine/awesome-godot).
+We also maintain official demos in their own [GitHub repository](https://github.com/Feelyengine/Feely-demo-projects)
+as well as a list of [awesome Feely community resources](https://github.com/Feelyengine/awesome-Feely).
 
 There are also a number of other
-[learning resources](https://docs.godotengine.org/en/latest/community/tutorials.html)
+[learning resources](https://docs.Feelyengine.org/en/latest/community/tutorials.html)
 provided by the community, such as text and video tutorials, demos, etc.
-Consult the [community channels](https://godotengine.org/community)
+Consult the [community channels](https://Feelyengine.org/community)
 for more information.
 
-[![Code Triagers Badge](https://www.codetriage.com/godotengine/godot/badges/users.svg)](https://www.codetriage.com/godotengine/godot)
-[![Translate on Weblate](https://hosted.weblate.org/widgets/godot-engine/-/godot/svg-badge.svg)](https://hosted.weblate.org/engage/godot-engine/?utm_source=widget)
-[![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/godotengine/godot)](https://www.tickgit.com/browse?repo=github.com/godotengine/godot)
+[![Code Triagers Badge](https://www.codetriage.com/Feelyengine/Feely/badges/users.svg)](https://www.codetriage.com/Feelyengine/Feely)
+[![Translate on Weblate](https://hosted.weblate.org/widgets/Feely-engine/-/Feely/svg-badge.svg)](https://hosted.weblate.org/engage/Feely-engine/?utm_source=widget)
+[![TODOs](https://badgen.net/https/api.tickgit.com/badgen/github.com/Feelyengine/Feely)](https://www.tickgit.com/browse?repo=github.com/Feelyengine/Feely)


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Godot has been replaced with Feely